### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Logger provides :
 
 ### Gradle
 ```groovy
-compile 'com.orhanobut:logger:1.1'
+compile 'com.orhanobut:Logger:1.1'
 ```
 
 ### Current Log system


### PR DESCRIPTION
Fix: com.orhanobut:logger:1.1 with lowercase L not resolvable because com.orhanobut:Logger:1.1  is with uppercase L inside repositories.