### PR TITLE
Use synchronize to avoid log messy when have multiple threads.

### DIFF
--- a/logger/src/main/java/com/orhanobut/logger/Logger.java
+++ b/logger/src/main/java/com/orhanobut/logger/Logger.java
@@ -261,7 +261,7 @@ public final class Logger {
     }
 
     /**
-     * This method should synchronized to avoid messy of logs' order.
+     * This method is synchronized in order to avoid messy of logs' order.
      */
     private synchronized static void log(int logType, String tag, String message, int methodCount) {
         if (settings.logLevel == LogLevel.NONE) {

--- a/logger/src/main/java/com/orhanobut/logger/Logger.java
+++ b/logger/src/main/java/com/orhanobut/logger/Logger.java
@@ -260,7 +260,10 @@ public final class Logger {
         }
     }
 
-    private static void log(int logType, String tag, String message, int methodCount) {
+    /**
+     * This method should synchronized to avoid messy of logs' order.
+     */
+    private synchronized static void log(int logType, String tag, String message, int methodCount) {
         if (settings.logLevel == LogLevel.NONE) {
             return;
         }


### PR DESCRIPTION
If multiple threads is running, the log header and content may messy, which is terrible.