### PR TITLE
Fixed ArrayIndexOutOfBounds for short stack traces

### DIFF
--- a/logger/src/main/java/com/orhanobut/logger/Logger.java
+++ b/logger/src/main/java/com/orhanobut/logger/Logger.java
@@ -366,6 +366,7 @@ public final class Logger {
 
         for (int i = methodCount; i > 0; i--) {
             int stackIndex = i + stackOffset;
+            stackIndex = correctStackIndex(trace, stackIndex);
             StringBuilder builder = new StringBuilder();
             builder.append("║ ")
                     .append(level)

--- a/logger/src/main/java/com/orhanobut/logger/Logger.java
+++ b/logger/src/main/java/com/orhanobut/logger/Logger.java
@@ -383,6 +383,13 @@ public final class Logger {
             logChunk(logType, tag, builder.toString());
         }
     }
+    
+    private static int correctStackIndex(final StackTraceElement[] trace, int stackIndex) {
+        while (stackIndex >= trace.length) {
+            stackIndex--;
+        }
+        return stackIndex;
+    }
 
     private static void logBottomBorder(int logType, String tag) {
         logChunk(logType, tag, BOTTOM_BORDER);


### PR DESCRIPTION
I had custom Error objects which shortens the stack trace and I would receive ArrayIndexOutOfBoundsExceptions. 

This fix will ensure that this won't happen. 

Hope you think this is ok!

