### PR TITLE
major changes

### DIFF
--- a/app/src/main/java/com/orhanobut/loggersample/MainActivity.java
+++ b/app/src/main/java/com/orhanobut/loggersample/MainActivity.java
@@ -16,8 +16,7 @@ public class MainActivity extends ActionBarActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        Logger.init()
-                .setMethodCount(1);
+        Logger.init("test").hideThreadInfo().setMethodCount(40);
 
         printNormalLog();
         printPretty();
@@ -28,6 +27,7 @@ public class MainActivity extends ActionBarActivity {
         Log.v(TAG, "i = 0 + 1");
         Log.v(TAG, Dummy.JSON_WITH_NO_LINE_BREAK);
         Log.v("test", Dummy.JSON_WITH_LINE_BREAK);
+
     }
 
     void printPretty() {
@@ -37,23 +37,24 @@ public class MainActivity extends ActionBarActivity {
         try {
             Class clazz = Class.forName("asdfasd");
         } catch (ClassNotFoundException e) {
-            Logger.e(e);
+            Logger.e(e, "something happened");
         }
 
         String test = "[" + Dummy.JSON_WITH_NO_LINE_BREAK + "," + Dummy.JSON_WITH_NO_LINE_BREAK + "]";
 
         Logger.json(Dummy.SMALL_SON_WITH_NO_LINE_BREAK);
 
+        Logger.d("test");
     }
 
     void test2() {
-        Logger.v("test2", 3);
-        Logger.v("test3", 0);
-        Logger.v("MYTAG", "test3", 2);
-        Logger.wtf("test3", 1);
-        Logger.d("", "logger with tag");
-        Logger.d("tag3", "logger with tag");
-        Logger.d("ta", "logger with tag");
+        Logger.v("test2");
+        Logger.v("test3");
+        Logger.v("MYTAG");
+        Logger.wtf("test3");
+        Logger.d("logger with tag");
+        Logger.t("tag").d("logger with tag");
+        Logger.t("tag", 3).d("logger with 3 method count");
     }
 
 }

--- a/logger/src/androidTest/java/com/orhanobut/logger/LoggerTest.java
+++ b/logger/src/androidTest/java/com/orhanobut/logger/LoggerTest.java
@@ -8,27 +8,6 @@ import junit.framework.TestCase;
  */
 public class LoggerTest extends TestCase {
 
-    public void testSetMethodCount() {
-        try {
-            Logger.init().setMethodCount(-1);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.init().setMethodCount(6);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.init().setMethodCount(3);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
     public void testSetTag() {
         try {
             Logger.init(null);
@@ -50,168 +29,11 @@ public class LoggerTest extends TestCase {
         }
     }
 
-    public void testSetLogDForMethodCount() {
-        try {
-            Logger.d("test", -1);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.d("test", 6);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.d("test", 3);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    public void testSetLogEForMethodCount() {
-        try {
-            Logger.e("test", -1);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.e("test", 6);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.e("test", 3);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    public void testSetLogWForMethodCount() {
-        try {
-            Logger.w("test", -1);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.w("test", 6);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.w("test", 3);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    public void testSetLogVForMethodCount() {
-        try {
-            Logger.v("test", -1);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.v("test", 6);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.v("test", 3);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    public void testSetLogWTFForMethodCount() {
-        try {
-            Logger.wtf("test", -1);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.wtf("test", 6);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.wtf("test", 3);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    public void testSetLogJsonForMethodCount() {
-        try {
-            Logger.json("{}", -1);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.json("{}", 6);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.json("{}", 3);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    public void testLogEforException() {
-        try {
-            Exception exception = null;
-            Logger.e(exception);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    public void testJson(){
+    public void testJson() {
         Logger.json("{\"test\":\"test\"}");
     }
 
-    public void testSetLogXmlForMethodCount(){
-        try {
-            Logger.xml("<xml></xml>", -1);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.xml("<xml></xml>", 6);
-            fail();
-        } catch (Exception e) {
-            Assert.assertTrue(true);
-        }
-        try {
-            Logger.xml("<xml></xml>", 3);
-            Assert.assertTrue(true);
-        } catch (Exception e) {
-            fail();
-        }
-    }
-
-    public void testXmlLogger(){
+    public void testXmlLogger() {
         Logger.xml("<note>" +
                 "<to>Tove</to>" +
                 "<from>Jani</from>" +
@@ -220,7 +42,34 @@ public class LoggerTest extends TestCase {
                 "</note>");
     }
 
-    public void testEmptyXml(){
+    public void testEmptyXml() {
         Logger.xml(" ");
+    }
+
+    public void testNegativeMethodCount() {
+        try {
+            Logger.t(-10).d("test");
+            fail();
+        } catch (Exception e) {
+            Assert.assertTrue(true);
+        }
+    }
+
+    public void testTagShouldNotBeNull() {
+        try {
+            Logger.init(null);
+            fail();
+        } catch (Exception e) {
+            Assert.assertTrue(true);
+        }
+    }
+
+    public void testStackTraceWithHugeMethodCount() {
+        try {
+            Logger.init("test").setMethodCount(40);
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            fail();
+        }
     }
 }

--- a/logger/src/main/java/com/orhanobut/logger/Logger.java
+++ b/logger/src/main/java/com/orhanobut/logger/Logger.java
@@ -1,23 +1,5 @@
 package com.orhanobut.logger;
 
-import android.text.TextUtils;
-import android.util.Log;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.StringReader;
-import java.io.StringWriter;
-
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
-
 /**
  * Logger is a wrapper of {@link android.util.Log}
  * But more pretty, simple and powerful
@@ -26,51 +8,9 @@ import javax.xml.transform.stream.StreamSource;
  */
 public final class Logger {
 
-    /**
-     * Android's max limit for a log entry is ~4076 bytes,
-     * so 4000 bytes is used as chunk size since default charset
-     * is UTF-8
-     */
-    private static final int CHUNK_SIZE = 4000;
-
-    /**
-     * It is used for json pretty print
-     */
-    private static final int JSON_INDENT = 4;
-
-    /**
-     * In order to prevent readability, max method count is restricted with 5
-     */
-    private static final int MAX_METHOD_COUNT = 5;
-
-    /**
-     * The minimum stack trace index, starts at this class after two native calls.
-     */
-    private static final int MIN_STACK_OFFSET = 3;
-
-    /**
-     * It is used to determine log settings such as method count, thread info visibility
-     */
-    private static final Settings settings = new Settings();
-
-    /**
-     * Drawing toolbox
-     */
-    private static final char TOP_LEFT_CORNER = '╔';
-    private static final char BOTTOM_LEFT_CORNER = '╚';
-    private static final char MIDDLE_CORNER = '╟';
-    private static final char HORIZONTAL_DOUBLE_LINE = '║';
-    private static final String DOUBLE_DIVIDER = "════════════════════════════════════════════";
-    private static final String SINGLE_DIVIDER = "────────────────────────────────────────────";
-    private static final String TOP_BORDER = TOP_LEFT_CORNER + DOUBLE_DIVIDER + DOUBLE_DIVIDER;
-    private static final String BOTTOM_BORDER = BOTTOM_LEFT_CORNER + DOUBLE_DIVIDER + DOUBLE_DIVIDER;
-    private static final String MIDDLE_BORDER = MIDDLE_CORNER + SINGLE_DIVIDER + SINGLE_DIVIDER;
-
-    /**
-     * TAG is used for the Log, the name is a little different
-     * in order to differentiate the logs easily with the filter
-     */
-    private static String TAG = "PRETTYLOGGER";
+    private static final Printer printer = new LoggerPrinter();
+    private static final int DEFAULT_METHOD_COUNT = 2;
+    private static final String DEFAULT_TAG = "PRETTYLOGGER";
 
     //no instance
     private Logger() {
@@ -82,7 +22,7 @@ public final class Logger {
      * @return the settings object
      */
     public static Settings init() {
-        return settings;
+        return printer.init(DEFAULT_TAG);
     }
 
     /**
@@ -91,143 +31,43 @@ public final class Logger {
      * @param tag is the given string which will be used in Logger
      */
     public static Settings init(String tag) {
-        if (tag == null) {
-            throw new NullPointerException("tag may not be null");
-        }
-        if (tag.trim().length() == 0) {
-            throw new IllegalStateException("tag may not be empty");
-        }
-        Logger.TAG = tag;
-        return settings;
+        return printer.init(tag);
     }
 
-    public static void d(String message) {
-        d(TAG, message);
+    public static Printer t(String tag) {
+        return printer.t(tag, DEFAULT_METHOD_COUNT);
     }
 
-    public static void d(String tag, String message) {
-        d(tag, message, settings.methodCount);
+    public static Printer t(int methodCount) {
+        return printer.t(null, methodCount);
     }
 
-    public static void d(String message, int methodCount) {
-        d(TAG, message, methodCount);
+    public static Printer t(String tag, int methodCount) {
+        return printer.t(tag, methodCount);
     }
 
-    public static void d(String tag, String message, int methodCount) {
-        validateMethodCount(methodCount);
-        log(Log.DEBUG, tag, message, methodCount);
+    public static void d(String message, Object... args) {
+        printer.d(message, args);
     }
 
-    public static void e(String message) {
-        e(TAG, message);
+    public static void e(String message, Object... args) {
+        printer.e(null, message, args);
     }
 
-    public static void e(String tag, String message) {
-        e(tag, message, null, settings.methodCount);
+    public static void e(Throwable throwable, String message, Object... args) {
+        printer.e(throwable, message, args);
     }
 
-    public static void e(Exception e) {
-        e(TAG, null, e, settings.methodCount);
+    public static void i(String message, Object... args) {
+        printer.i(message, args);
     }
 
-    public static void e(String tag, Exception e) {
-        e(tag, null, e, settings.methodCount);
+    public static void v(String message, Object... args) {
+        printer.v(message, args);
     }
 
-    public static void e(String message, int methodCount) {
-        validateMethodCount(methodCount);
-        e(TAG, message, methodCount);
-    }
-
-    public static void e(String tag, String message, int methodCount) {
-        validateMethodCount(methodCount);
-        e(tag, message, null, methodCount);
-    }
-
-    public static void e(String tag, String message, Exception e) {
-        e(tag, message, e, settings.methodCount);
-    }
-
-    public static void e(String tag, String message, Exception e, int methodCount) {
-        validateMethodCount(methodCount);
-        if (e != null && message != null) {
-            message += " : " + e.toString();
-        }
-        if (e != null && message == null) {
-            message = e.toString();
-        }
-        if (message == null) {
-            message = "No message/exception is set";
-        }
-        log(Log.ERROR, tag, message, methodCount);
-    }
-
-    public static void w(String message) {
-        w(TAG, message);
-    }
-
-    public static void w(String tag, String message) {
-        w(tag, message, settings.methodCount);
-    }
-
-    public static void w(String message, int methodCount) {
-        w(TAG, message, methodCount);
-    }
-
-    public static void w(String tag, String message, int methodCount) {
-        validateMethodCount(methodCount);
-        log(Log.WARN, tag, message, methodCount);
-    }
-
-    public static void i(String message) {
-        i(TAG, message);
-    }
-
-    public static void i(String tag, String message) {
-        i(tag, message, settings.methodCount);
-    }
-
-    public static void i(String message, int methodCount) {
-        i(TAG, message, methodCount);
-    }
-
-    public static void i(String tag, String message, int methodCount) {
-        validateMethodCount(methodCount);
-        log(Log.INFO, tag, message, methodCount);
-    }
-
-    public static void v(String message) {
-        v(TAG, message);
-    }
-
-    public static void v(String tag, String message) {
-        v(tag, message, settings.methodCount);
-    }
-
-    public static void v(String message, int methodCount) {
-        v(TAG, message, methodCount);
-    }
-
-    public static void v(String tag, String message, int methodCount) {
-        validateMethodCount(methodCount);
-        log(Log.VERBOSE, tag, message, methodCount);
-    }
-
-    public static void wtf(String message) {
-        wtf(TAG, message);
-    }
-
-    public static void wtf(String tag, String message) {
-        wtf(tag, message, settings.methodCount);
-    }
-
-    public static void wtf(String message, int methodCount) {
-        wtf(TAG, message, methodCount);
-    }
-
-    public static void wtf(String tag, String message, int methodCount) {
-        validateMethodCount(methodCount);
-        log(Log.ASSERT, tag, message, methodCount);
+    public static void wtf(String message, Object... args) {
+        printer.wtf(message, args);
     }
 
     /**
@@ -236,252 +76,16 @@ public final class Logger {
      * @param json the json content
      */
     public static void json(String json) {
-        json(TAG, json);
-    }
-
-    public static void json(String tag, String json) {
-        json(tag, json, settings.methodCount);
-    }
-
-    public static void json(String json, int methodCount) {
-        json(TAG, json, methodCount);
+        printer.json(json);
     }
 
     /**
      * Formats the json content and print it
      *
-     * @param json        the json content
-     * @param methodCount number of the method that will be printed
-     */
-    public static void json(String tag, String json, int methodCount) {
-        validateMethodCount(methodCount);
-        if (TextUtils.isEmpty(json)) {
-            d(tag, "Empty/Null json content", methodCount);
-            return;
-        }
-        try {
-            if (json.startsWith("{")) {
-                JSONObject jsonObject = new JSONObject(json);
-                String message = jsonObject.toString(JSON_INDENT);
-                d(tag, message, methodCount);
-                return;
-            }
-            if (json.startsWith("[")) {
-                JSONArray jsonArray = new JSONArray(json);
-                String message = jsonArray.toString(JSON_INDENT);
-                d(tag, message, methodCount);
-            }
-        } catch (JSONException e) {
-            d(tag, e.getCause().getMessage() + "\n" + json, methodCount);
-        }
-    }
-
-    /**
-     * Formats the json content and print it
-     *
-     * @param xml the json content
+     * @param xml the xml content
      */
     public static void xml(String xml) {
-        xml(TAG, xml);
-    }
-
-    public static void xml(String tag, String xml) {
-        xml(tag, xml, settings.methodCount);
-    }
-
-    public static void xml(String xml, int methodCount) {
-        xml(TAG, xml, methodCount);
-    }
-
-    /**
-     * Formats the json content and print it
-     * @param xml         the xml content
-     * @param methodCount number of the method that will be printed
-     */
-    public static void xml(String tag, String xml, int methodCount) {
-        validateMethodCount(methodCount);
-        if (TextUtils.isEmpty(xml)) {
-            d(tag, "Empty/Null xml content", methodCount);
-            return;
-        }
-
-        try {
-            Source xmlInput = new StreamSource(new StringReader(xml));
-            StreamResult xmlOutput = new StreamResult(new StringWriter());
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
-            transformer.transform(xmlInput, xmlOutput);
-            d(tag, xmlOutput.getWriter().toString().replaceFirst(">", ">\n"), methodCount);
-        } catch (TransformerException  e) {
-            d(tag, e.getCause().getMessage() + "\n" + xml, methodCount);
-        }
-    }
-
-    /**
-     * This method is synchronized in order to avoid messy of logs' order.
-     */
-    private synchronized static void log(int logType, String tag, String message, int methodCount) {
-        if (settings.logLevel == LogLevel.NONE) {
-            return;
-        }
-        logTopBorder(logType, tag);
-        logHeaderContent(logType, tag, methodCount);
-
-        //get bytes of message with system's default charset (which is UTF-8 for Android)
-        byte[] bytes = message.getBytes();
-        int length = bytes.length;
-        if (length <= CHUNK_SIZE) {
-            if (methodCount > 0) {
-                logDivider(logType, tag);
-            }
-            logContent(logType, tag, message);
-            logBottomBorder(logType, tag);
-            return;
-        }
-        if (methodCount > 0) {
-            logDivider(logType, tag);
-        }
-        for (int i = 0; i < length; i += CHUNK_SIZE) {
-            int count = Math.min(length - i, CHUNK_SIZE);
-            //create a new String with system's default charset (which is UTF-8 for Android)
-            logContent(logType, tag, new String(bytes, i, count));
-        }
-        logBottomBorder(logType, tag);
-    }
-
-    private static void logTopBorder(int logType, String tag) {
-        logChunk(logType, tag, TOP_BORDER);
-    }
-
-    private static void logHeaderContent(int logType, String tag, int methodCount) {
-        StackTraceElement[] trace = Thread.currentThread().getStackTrace();
-        if (settings.showThreadInfo) {
-            logChunk(logType, tag, HORIZONTAL_DOUBLE_LINE + " Thread: " + Thread.currentThread().getName());
-            logDivider(logType, tag);
-        }
-        String level = "";
-
-        int stackOffset = getStackOffset(trace);
-
-        for (int i = methodCount; i > 0; i--) {
-            int stackIndex = i + stackOffset;
-            StringBuilder builder = new StringBuilder();
-            builder.append("║ ")
-                    .append(level)
-                    .append(getSimpleClassName(trace[stackIndex].getClassName()))
-                    .append(".")
-                    .append(trace[stackIndex].getMethodName())
-                    .append(" ")
-                    .append(" (")
-                    .append(trace[stackIndex].getFileName())
-                    .append(":")
-                    .append(trace[stackIndex].getLineNumber())
-                    .append(")");
-            level += "   ";
-            logChunk(logType, tag, builder.toString());
-        }
-    }
-
-    private static void logBottomBorder(int logType, String tag) {
-        logChunk(logType, tag, BOTTOM_BORDER);
-    }
-
-    private static void logDivider(int logType, String tag) {
-        logChunk(logType, tag, MIDDLE_BORDER);
-    }
-
-    private static void logContent(int logType, String tag, String chunk) {
-        String[] lines = chunk.split(System.getProperty("line.separator"));
-        for (String line : lines) {
-            logChunk(logType, tag, HORIZONTAL_DOUBLE_LINE + " " + line);
-        }
-    }
-
-    private static void logChunk(int logType, String tag, String chunk) {
-        String finalTag = formatTag(tag);
-        switch (logType) {
-            case Log.ERROR:
-                Log.e(finalTag, chunk);
-                break;
-            case Log.INFO:
-                Log.i(finalTag, chunk);
-                break;
-            case Log.VERBOSE:
-                Log.v(finalTag, chunk);
-                break;
-            case Log.WARN:
-                Log.w(finalTag, chunk);
-                break;
-            case Log.ASSERT:
-                Log.wtf(finalTag, chunk);
-                break;
-            case Log.DEBUG:
-                // Fall through, log debug by default
-            default:
-                Log.d(finalTag, chunk);
-                break;
-        }
-    }
-
-    private static String getSimpleClassName(String name) {
-        int lastIndex = name.lastIndexOf(".");
-        return name.substring(lastIndex + 1);
-    }
-
-    private static void validateMethodCount(int methodCount) {
-        if (methodCount < 0 || methodCount > MAX_METHOD_COUNT) {
-            throw new IllegalStateException("methodCount must be > 0 and < 5");
-        }
-    }
-
-    private static String formatTag(String tag) {
-        if (!TextUtils.isEmpty(tag) && !TextUtils.equals(TAG, tag)) {
-            return TAG + "-" + tag;
-        }
-        return TAG;
-    }
-
-    public static class Settings {
-        int methodCount = 2;
-        boolean showThreadInfo = true;
-
-        /**
-         * Determines how logs will printed
-         */
-        LogLevel logLevel = LogLevel.FULL;
-
-        public Settings hideThreadInfo() {
-            showThreadInfo = false;
-            return this;
-        }
-
-        public Settings setMethodCount(int methodCount) {
-            validateMethodCount(methodCount);
-            this.methodCount = methodCount;
-            return this;
-        }
-
-        public Settings setLogLevel(LogLevel logLevel) {
-            this.logLevel = logLevel;
-            return this;
-        }
-    }
-
-    /**
-     * Determines the starting index of the stack trace, after method calls made by this class.
-     *
-     * @param trace the stack trace
-     * @return  the stack offset
-     */
-    private static int getStackOffset(StackTraceElement[] trace) {
-        for (int i = MIN_STACK_OFFSET; i < trace.length; i++) {
-            StackTraceElement e = trace[i];
-            if (!e.getClassName().equals(Logger.class.getName())) {
-                return --i;
-            }
-        }
-        return -1;
+        printer.xml(xml);
     }
 
 }

--- a/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
+++ b/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
@@ -1,0 +1,371 @@
+package com.orhanobut.logger;
+
+import android.text.TextUtils;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+/**
+ * Logger is a wrapper of {@link Log}
+ * But more pretty, simple and powerful
+ *
+ * @author Orhan Obut
+ */
+final class LoggerPrinter implements Printer {
+
+    /**
+     * Android's max limit for a log entry is ~4076 bytes,
+     * so 4000 bytes is used as chunk size since default charset
+     * is UTF-8
+     */
+    private static final int CHUNK_SIZE = 4000;
+
+    /**
+     * It is used for json pretty print
+     */
+    private static final int JSON_INDENT = 4;
+
+    /**
+     * The minimum stack trace index, starts at this class after two native calls.
+     */
+    private static final int MIN_STACK_OFFSET = 3;
+
+    /**
+     * It is used to determine log settings such as method count, thread info visibility
+     */
+    private static final Settings settings = new Settings();
+
+    /**
+     * Drawing toolbox
+     */
+    private static final char TOP_LEFT_CORNER = '╔';
+    private static final char BOTTOM_LEFT_CORNER = '╚';
+    private static final char MIDDLE_CORNER = '╟';
+    private static final char HORIZONTAL_DOUBLE_LINE = '║';
+    private static final String DOUBLE_DIVIDER = "════════════════════════════════════════════";
+    private static final String SINGLE_DIVIDER = "────────────────────────────────────────────";
+    private static final String TOP_BORDER = TOP_LEFT_CORNER + DOUBLE_DIVIDER + DOUBLE_DIVIDER;
+    private static final String BOTTOM_BORDER = BOTTOM_LEFT_CORNER + DOUBLE_DIVIDER + DOUBLE_DIVIDER;
+    private static final String MIDDLE_BORDER = MIDDLE_CORNER + SINGLE_DIVIDER + SINGLE_DIVIDER;
+
+    /**
+     * TAG is used for the Log, the name is a little different
+     * in order to differentiate the logs easily with the filter
+     */
+    private static String TAG = "PRETTYLOGGER";
+
+    /**
+     * Localize single tag and method count for each thread
+     */
+    private static final ThreadLocal<String> LOCAL_TAG = new ThreadLocal<>();
+    private static final ThreadLocal<Integer> LOCAL_METHOD_COUNT = new ThreadLocal<>();
+
+    /**
+     * It is used to change the tag
+     *
+     * @param tag is the given string which will be used in Logger
+     */
+    @Override
+    public Settings init(String tag) {
+        if (tag == null) {
+            throw new NullPointerException("tag may not be null");
+        }
+        if (tag.trim().length() == 0) {
+            throw new IllegalStateException("tag may not be empty");
+        }
+        LoggerPrinter.TAG = tag;
+        return settings;
+    }
+
+    @Override
+    public Printer t(String tag, int methodCount) {
+        if (tag != null) {
+            LOCAL_TAG.set(tag);
+        }
+        LOCAL_METHOD_COUNT.set(methodCount);
+        return this;
+    }
+
+    @Override
+    public void d(String message, Object... args) {
+        log(Log.DEBUG, message, args);
+    }
+
+    @Override
+    public void e(String message, Object... args) {
+        e(null, message, args);
+    }
+
+    @Override
+    public void e(Throwable throwable, String message, Object... args) {
+        if (throwable != null && message != null) {
+            message += " : " + throwable.toString();
+        }
+        if (throwable != null && message == null) {
+            message = throwable.toString();
+        }
+        if (message == null) {
+            message = "No message/exception is set";
+        }
+        log(Log.ERROR, message, args);
+    }
+
+    @Override
+    public void i(String message, Object... args) {
+        log(Log.INFO, message, args);
+    }
+
+    @Override
+    public void v(String message, Object... args) {
+        log(Log.VERBOSE, message, args);
+    }
+
+    @Override
+    public void wtf(String message, Object... args) {
+        log(Log.ASSERT, message, args);
+    }
+
+    /**
+     * Formats the json content and print it
+     *
+     * @param json the json content
+     */
+    @Override
+    public void json(String json) {
+        String tag = getTag();
+        int methodCount = getMethodCount();
+
+        if (TextUtils.isEmpty(json)) {
+            d(tag, "Empty/Null json content", methodCount);
+            return;
+        }
+        try {
+            if (json.startsWith("{")) {
+                JSONObject jsonObject = new JSONObject(json);
+                String message = jsonObject.toString(JSON_INDENT);
+                d(tag, message, methodCount);
+                return;
+            }
+            if (json.startsWith("[")) {
+                JSONArray jsonArray = new JSONArray(json);
+                String message = jsonArray.toString(JSON_INDENT);
+                d(tag, message, methodCount);
+            }
+        } catch (JSONException e) {
+            d(tag, e.getCause().getMessage() + "\n" + json, methodCount);
+        }
+    }
+
+    /**
+     * Formats the json content and print it
+     *
+     * @param xml the xml content
+     */
+    @Override
+    public void xml(String xml) {
+        String tag = getTag();
+        int methodCount = getMethodCount();
+        if (TextUtils.isEmpty(xml)) {
+            d(tag, "Empty/Null xml content", methodCount);
+            return;
+        }
+
+        try {
+            Source xmlInput = new StreamSource(new StringReader(xml));
+            StreamResult xmlOutput = new StreamResult(new StringWriter());
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+            transformer.transform(xmlInput, xmlOutput);
+            d(tag, xmlOutput.getWriter().toString().replaceFirst(">", ">\n"), methodCount);
+        } catch (TransformerException e) {
+            d(tag, e.getCause().getMessage() + "\n" + xml, methodCount);
+        }
+    }
+
+    /**
+     * This method is synchronized in order to avoid messy of logs' order.
+     */
+    private synchronized void log(int logType, String msg, Object... args) {
+        if (settings.getLogLevel() == LogLevel.NONE) {
+            return;
+        }
+        String tag = getTag();
+        String message = createMessage(msg, args);
+        int methodCount = getMethodCount();
+
+        logTopBorder(logType, tag);
+        logHeaderContent(logType, tag, methodCount);
+
+        //get bytes of message with system's default charset (which is UTF-8 for Android)
+        byte[] bytes = message.getBytes();
+        int length = bytes.length;
+        if (length <= CHUNK_SIZE) {
+            if (methodCount > 0) {
+                logDivider(logType, tag);
+            }
+            logContent(logType, tag, message);
+            logBottomBorder(logType, tag);
+            return;
+        }
+        if (methodCount > 0) {
+            logDivider(logType, tag);
+        }
+        for (int i = 0; i < length; i += CHUNK_SIZE) {
+            int count = Math.min(length - i, CHUNK_SIZE);
+            //create a new String with system's default charset (which is UTF-8 for Android)
+            logContent(logType, tag, new String(bytes, i, count));
+        }
+        logBottomBorder(logType, tag);
+    }
+
+    private void logTopBorder(int logType, String tag) {
+        logChunk(logType, tag, TOP_BORDER);
+    }
+
+    private void logHeaderContent(int logType, String tag, int methodCount) {
+        StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+        if (settings.isShowThreadInfo()) {
+            logChunk(logType, tag, HORIZONTAL_DOUBLE_LINE + " Thread: " + Thread.currentThread().getName());
+            logDivider(logType, tag);
+        }
+        String level = "";
+
+        int stackOffset = getStackOffset(trace);
+
+        if (methodCount + stackOffset > trace.length) {
+            methodCount = trace.length - stackOffset - 1;
+        }
+
+        for (int i = methodCount; i > 0; i--) {
+            int stackIndex = i + stackOffset;
+            StringBuilder builder = new StringBuilder();
+            builder.append("║ ")
+                    .append(level)
+                    .append(getSimpleClassName(trace[stackIndex].getClassName()))
+                    .append(".")
+                    .append(trace[stackIndex].getMethodName())
+                    .append(" ")
+                    .append(" (")
+                    .append(trace[stackIndex].getFileName())
+                    .append(":")
+                    .append(trace[stackIndex].getLineNumber())
+                    .append(")");
+            level += "   ";
+            logChunk(logType, tag, builder.toString());
+        }
+    }
+
+    private void logBottomBorder(int logType, String tag) {
+        logChunk(logType, tag, BOTTOM_BORDER);
+    }
+
+    private void logDivider(int logType, String tag) {
+        logChunk(logType, tag, MIDDLE_BORDER);
+    }
+
+    private void logContent(int logType, String tag, String chunk) {
+        String[] lines = chunk.split(System.getProperty("line.separator"));
+        for (String line : lines) {
+            logChunk(logType, tag, HORIZONTAL_DOUBLE_LINE + " " + line);
+        }
+    }
+
+    private void logChunk(int logType, String tag, String chunk) {
+        String finalTag = formatTag(tag);
+        switch (logType) {
+            case Log.ERROR:
+                Log.e(finalTag, chunk);
+                break;
+            case Log.INFO:
+                Log.i(finalTag, chunk);
+                break;
+            case Log.VERBOSE:
+                Log.v(finalTag, chunk);
+                break;
+            case Log.WARN:
+                Log.w(finalTag, chunk);
+                break;
+            case Log.ASSERT:
+                Log.wtf(finalTag, chunk);
+                break;
+            case Log.DEBUG:
+                // Fall through, log debug by default
+            default:
+                Log.d(finalTag, chunk);
+                break;
+        }
+    }
+
+    private String getSimpleClassName(String name) {
+        int lastIndex = name.lastIndexOf(".");
+        return name.substring(lastIndex + 1);
+    }
+
+    private String formatTag(String tag) {
+        if (!TextUtils.isEmpty(tag) && !TextUtils.equals(TAG, tag)) {
+            return TAG + "-" + tag;
+        }
+        return TAG;
+    }
+
+    /**
+     * @return the appropriate tag based on local or global
+     */
+    private String getTag() {
+        String tag = LOCAL_TAG.get();
+        if (tag != null) {
+            LOCAL_TAG.remove();
+            return tag;
+        }
+        return TAG;
+    }
+
+    private String createMessage(String message, Object... args) {
+        return args.length == 0 ? message : String.format(message, args);
+    }
+
+    private int getMethodCount() {
+        Integer count = LOCAL_METHOD_COUNT.get();
+        int result = settings.getMethodCount();
+        if (count != null) {
+            LOCAL_METHOD_COUNT.remove();
+            result = count;
+        }
+        if (result < 0) {
+            throw new IllegalStateException("methodCount cannot be negative");
+        }
+        return result;
+    }
+
+    /**
+     * Determines the starting index of the stack trace, after method calls made by this class.
+     *
+     * @param trace the stack trace
+     * @return the stack offset
+     */
+    private int getStackOffset(StackTraceElement[] trace) {
+        for (int i = MIN_STACK_OFFSET; i < trace.length; i++) {
+            StackTraceElement e = trace[i];
+            String name = e.getClassName();
+            if (!name.equals(LoggerPrinter.class.getName()) && !name.equals(Logger.class.getName())) {
+                return --i;
+            }
+        }
+        return -1;
+    }
+
+}

--- a/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
+++ b/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
@@ -246,6 +246,7 @@ final class LoggerPrinter implements Printer {
 
         int stackOffset = getStackOffset(trace);
 
+        //corresponding method count with the current stack may exceeds the stack trace. Trims the count
         if (methodCount + stackOffset > trace.length) {
             methodCount = trace.length - stackOffset - 1;
         }

--- a/logger/src/main/java/com/orhanobut/logger/Printer.java
+++ b/logger/src/main/java/com/orhanobut/logger/Printer.java
@@ -1,0 +1,27 @@
+package com.orhanobut.logger;
+
+/**
+ * @author Orhan Obut
+ */
+public interface Printer {
+
+    Printer t(String tag, int methodCount);
+
+    Settings init(String tag);
+
+    void d(String message, Object... args);
+
+    void e(String message, Object... args);
+
+    void e(Throwable throwable, String message, Object... args);
+
+    void i(String message, Object... args);
+
+    void v(String message, Object... args);
+
+    void wtf(String message, Object... args);
+
+    void json(String json);
+
+    void xml(String xml);
+}

--- a/logger/src/main/java/com/orhanobut/logger/Settings.java
+++ b/logger/src/main/java/com/orhanobut/logger/Settings.java
@@ -1,0 +1,42 @@
+package com.orhanobut.logger;
+
+/**
+ * @author Orhan Obut
+ */
+public final class Settings {
+
+    private int methodCount = 2;
+    private boolean showThreadInfo = true;
+
+    /**
+     * Determines how logs will printed
+     */
+    private LogLevel logLevel = LogLevel.FULL;
+
+    public Settings hideThreadInfo() {
+        showThreadInfo = false;
+        return this;
+    }
+
+    public Settings setMethodCount(int methodCount) {
+        this.methodCount = methodCount;
+        return this;
+    }
+
+    public Settings setLogLevel(LogLevel logLevel) {
+        this.logLevel = logLevel;
+        return this;
+    }
+
+    public int getMethodCount() {
+        return methodCount;
+    }
+
+    public boolean isShowThreadInfo() {
+        return showThreadInfo;
+    }
+
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
+}


### PR DESCRIPTION
- varargs added
```java
Logger.d("message %d %s", 23, "test");
```
- e(Exception e) is removed
- MethodCount and Tag definitions are moved from constructor to a new method 
```java
Logger.t(TAG, METHOD_COUNT).d(MESSAGE);
```
- bug fix for indexoutofbound
- new structure