### PR TITLE
issue#55 Handling NPE

### DIFF
--- a/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
+++ b/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
@@ -208,6 +208,10 @@ final class LoggerPrinter implements Printer {
     String message = createMessage(msg, args);
     int methodCount = getMethodCount();
 
+    if (TextUtils.isEmpty(message)) {
+      message = "Empty/NULL log message";
+    }
+
     logTopBorder(logType, tag);
     logHeaderContent(logType, tag, methodCount);
 


### PR DESCRIPTION
#55 Handles NPE
When null is given as a parameter, log() function tries to get bytes
of it, thus NPE exception occurs