### PR TITLE
Removing Android dependency from LoggerPrinter

### DIFF
--- a/logger/src/main/java/com/orhanobut/logger/AndroidLogTool.java
+++ b/logger/src/main/java/com/orhanobut/logger/AndroidLogTool.java
@@ -2,7 +2,7 @@ package com.orhanobut.logger;
 
 import android.util.Log;
 
-public class AndroidLogTool implements LogTool {
+class AndroidLogTool implements LogTool {
   @Override public void d(String tag, String message) {
     Log.d(tag, message);
   }

--- a/logger/src/main/java/com/orhanobut/logger/Helper.java
+++ b/logger/src/main/java/com/orhanobut/logger/Helper.java
@@ -18,8 +18,6 @@
  */
 package com.orhanobut.logger;
 
-import android.support.annotation.Nullable;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.UnknownHostException;
@@ -36,7 +34,7 @@ final class Helper {
      * @param str the string to be examined
      * @return true if str is null or zero length
      */
-    static boolean isEmpty(@Nullable CharSequence str) {
+    static boolean isEmpty(CharSequence str) {
         return str == null || str.length() == 0;
     }
 

--- a/logger/src/main/java/com/orhanobut/logger/Helper.java
+++ b/logger/src/main/java/com/orhanobut/logger/Helper.java
@@ -1,0 +1,96 @@
+/*
+ * (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE:
+ * Code is copied from following Android classes: android.util.Log, android.text.TextUtils
+ */
+package com.orhanobut.logger;
+
+import android.support.annotation.Nullable;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.UnknownHostException;
+
+/**
+ * Helper util class to be used instead of Android methods to avoid direct dependency and enable
+ * unit testing on Android projects.
+ */
+final class Helper {
+
+    /**
+     * Returns true if the string is null or 0-length.
+     *
+     * @param str the string to be examined
+     * @return true if str is null or zero length
+     */
+    static boolean isEmpty(@Nullable CharSequence str) {
+        return str == null || str.length() == 0;
+    }
+
+    /**
+     * Returns true if a and b are equal, including if they are both null.
+     * <p><i>Note: In platform versions 1.1 and earlier, this method only worked well if
+     * both the arguments were instances of String.</i></p>
+     *
+     * @param a first CharSequence to check
+     * @param b second CharSequence to check
+     * @return true if a and b are equal
+     */
+    static boolean equals(CharSequence a, CharSequence b) {
+        if (a == b) return true;
+        int length;
+        if (a != null && b != null && (length = a.length()) == b.length()) {
+            if (a instanceof String && b instanceof String) {
+                return a.equals(b);
+            } else {
+                for (int i = 0; i < length; i++) {
+                    if (a.charAt(i) != b.charAt(i)) return false;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Copied from "android.util.Log.getStackTraceString()" in order to avoid usage of Android stack
+     * in unit tests.
+     *
+     * @return Stack trace in form of String
+     */
+    static String getStackTraceString(Throwable tr) {
+        if (tr == null) {
+            return "";
+        }
+
+        // This is to reduce the amount of log spew that apps do in the non-error
+        // condition of the network being unavailable.
+        Throwable t = tr;
+        while (t != null) {
+            if (t instanceof UnknownHostException) {
+                return "";
+            }
+            t = t.getCause();
+        }
+
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        tr.printStackTrace(pw);
+        pw.flush();
+        return sw.toString();
+    }
+
+}

--- a/logger/src/main/java/com/orhanobut/logger/Helper.java
+++ b/logger/src/main/java/com/orhanobut/logger/Helper.java
@@ -28,6 +28,10 @@ import java.net.UnknownHostException;
  */
 final class Helper {
 
+    private Helper() {
+        // Hidden constructor.
+    }
+
     /**
      * Returns true if the string is null or 0-length.
      *

--- a/logger/src/main/java/com/orhanobut/logger/Helper.java
+++ b/logger/src/main/java/com/orhanobut/logger/Helper.java
@@ -46,18 +46,23 @@ final class Helper {
      * @param a first CharSequence to check
      * @param b second CharSequence to check
      * @return true if a and b are equal
+     *
+     * NOTE: Logic slightly change due to strict policy on CI -
+     * "Inner assignments should be avoided"
      */
     static boolean equals(CharSequence a, CharSequence b) {
         if (a == b) return true;
-        int length;
-        if (a != null && b != null && (length = a.length()) == b.length()) {
-            if (a instanceof String && b instanceof String) {
-                return a.equals(b);
-            } else {
-                for (int i = 0; i < length; i++) {
-                    if (a.charAt(i) != b.charAt(i)) return false;
+        if (a != null && b != null) {
+            int length = a.length();
+            if (length == b.length()) {
+                if (a instanceof String && b instanceof String) {
+                    return a.equals(b);
+                } else {
+                    for (int i = 0; i < length; i++) {
+                        if (a.charAt(i) != b.charAt(i)) return false;
+                    }
+                    return true;
                 }
-                return true;
             }
         }
         return false;

--- a/logger/src/main/java/com/orhanobut/logger/Helper.java
+++ b/logger/src/main/java/com/orhanobut/logger/Helper.java
@@ -1,5 +1,5 @@
 /*
- * (C) 2006 The Android Open Source Project
+ * Copyright 2015 Orhan Obut
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * NOTICE:
- * Code is copied from following Android classes: android.util.Log, android.text.TextUtils
+ * This software contains code derived from the following Android classes:
+ * android.util.Log, android.text.TextUtils.
  */
 package com.orhanobut.logger;
 

--- a/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
+++ b/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
@@ -1,8 +1,5 @@
 package com.orhanobut.logger;
 
-import android.text.TextUtils;
-import android.util.Log;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -117,7 +114,7 @@ final class LoggerPrinter implements Printer {
 
   @Override public void e(Throwable throwable, String message, Object... args) {
     if (throwable != null && message != null) {
-      message += " : " + Log.getStackTraceString(throwable);
+      message += " : " + Helper.getStackTraceString(throwable);
     }
     if (throwable != null && message == null) {
       message = throwable.toString();
@@ -150,7 +147,7 @@ final class LoggerPrinter implements Printer {
    * @param json the json content
    */
   @Override public void json(String json) {
-    if (TextUtils.isEmpty(json)) {
+    if (Helper.isEmpty(json)) {
       d("Empty/Null json content");
       return;
     }
@@ -178,7 +175,7 @@ final class LoggerPrinter implements Printer {
    * @param xml the xml content
    */
   @Override public void xml(String xml) {
-    if (TextUtils.isEmpty(xml)) {
+    if (Helper.isEmpty(xml)) {
       d("Empty/Null xml content");
       return;
     }
@@ -210,7 +207,7 @@ final class LoggerPrinter implements Printer {
     String message = createMessage(msg, args);
     int methodCount = getMethodCount();
 
-    if (TextUtils.isEmpty(message)) {
+    if (Helper.isEmpty(message)) {
       message = "Empty/NULL log message";
     }
 
@@ -327,7 +324,7 @@ final class LoggerPrinter implements Printer {
   }
 
   private String formatTag(String tag) {
-    if (!TextUtils.isEmpty(tag) && !TextUtils.equals(this.tag, tag)) {
+    if (!Helper.isEmpty(tag) && !Helper.equals(this.tag, tag)) {
       return this.tag + "-" + tag;
     }
     return this.tag;


### PR DESCRIPTION
In order to have Logger in Android unit tests, Logger classes
should not depend on Android internals, otherwise exception
"Method ... not mocked." will be thrown.
For more info: https://goo.gl/Cl0xu3

In this commit, instead of introducing more dependecy from other some 3rd
party lib (Appache etc) to do the same task, code is copppied from relevant
Android methods to reduce change impact.