### PR TITLE
added options for FileLogger

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -7,6 +7,7 @@
   <!--module name="NewlineAtEndOfFile"/-->
   <module name="FileLength"/>
   <module name="FileTabCharacter"/>
+  <module name="SuppressWarningsFilter" />
 
   <!-- Trailing spaces -->
   <module name="RegexpSingleline">
@@ -27,6 +28,7 @@
   </module>
 
   <module name="TreeWalker">
+    <module name="SuppressWarningsHolder" />
     <!-- <property name="cacheFile" value="${checkstyle.cache.file}"/>                    -->
 
 

--- a/logger/src/main/java/com/orhanobut/logger/AbstractAndroidFileLogger.java
+++ b/logger/src/main/java/com/orhanobut/logger/AbstractAndroidFileLogger.java
@@ -1,0 +1,119 @@
+package com.orhanobut.logger;
+
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Looper;
+import android.os.Message;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * Abstract class that takes care of background threading the file log operation on Android.
+ * All calls to {@link #writeLog(FileWriter, int, String, String)} are guaranteed
+ * to be called on a single background thread,
+ * implementing classes are free to directly perform I/O operations there.
+ */
+public abstract class AbstractAndroidFileLogger implements FileLogger {
+
+  /**
+   * This is always called on a single background thread.
+   * Implementing classes must ONLY write to the fileWriter and nothing more.
+   * The abstract class takes care of everything else including close the stream and catching IOException
+   *
+   * @param fileWriter an instance of FileWriter already initialised to the correct file
+   * @param level      the log level
+   * @param tag        the tag logged to
+   * @param message    the log message
+   */
+  protected abstract void writeLog(FileWriter fileWriter, int level, String tag, String message) throws IOException;
+
+  private final Handler handler;
+  private final int maxFileSize;
+  private final String folder;
+
+  /**
+   * Default constructor.
+   *
+   * @param maxFileSize max size of a file before breaking it into a new log file
+   * @param folder      folder to create the log files.
+   */
+  public AbstractAndroidFileLogger(int maxFileSize, String folder) {
+    this.maxFileSize = maxFileSize;
+    this.folder = folder;
+    HandlerThread ht = new HandlerThread("AndroidFileLogger." + folder);
+    ht.start();
+    handler = new WriteHandler(ht.getLooper());
+  }
+
+  @Override public void log(int level, String tag, String message) {
+    // do nothing on the calling thread, simply pass the tag/msg to the background thread
+    handler.sendMessage(handler.obtainMessage(level, new String[]{tag, message}));
+  }
+
+  //region helper to generate file names
+  private File getLogFile(String folderName, String fileName) {
+
+    File folder = new File(folderName);
+    if (!folder.exists()) {
+      folder.mkdirs();
+    }
+
+    int newFileCount = 0;
+    File newFile;
+    File existingFile = null;
+
+    newFile = new File(folder, String.format("%s_%s.csv", fileName, newFileCount));
+    while (newFile.exists()) {
+      existingFile = newFile;
+      newFileCount++;
+      newFile = new File(folder, String.format("%s_%s.csv", fileName, newFileCount));
+    }
+
+    if (existingFile != null) {
+      if (existingFile.length() >= maxFileSize) {
+        return newFile;
+      } else {
+        return existingFile;
+      }
+    }
+
+    return newFile;
+  }
+  //endregion
+
+  //region handler to write to disk on background thread
+  private class WriteHandler extends Handler {
+
+    private WriteHandler(Looper looper) {
+      super(looper);
+    }
+
+    @SuppressWarnings("checkstyle:emptyblock")
+    @Override public void handleMessage(Message msg) {
+
+      String[] data = (String[]) msg.obj;
+
+      FileWriter fileWriter = null;
+      File logFile = getLogFile(folder, "logs");
+
+      try {
+        fileWriter = new FileWriter(logFile, true);
+
+        writeLog(fileWriter, msg.what, data[0], data[1]);
+
+        fileWriter.flush();
+        fileWriter.close();
+      } catch (IOException e) {
+        if (fileWriter != null) {
+          try {
+            fileWriter.flush();
+            fileWriter.close();
+          } catch (IOException e1) { /* fail silently */ }
+        }
+      }
+    }
+  }
+  //endregion
+}

--- a/logger/src/main/java/com/orhanobut/logger/AndroidCsvFileLogger.java
+++ b/logger/src/main/java/com/orhanobut/logger/AndroidCsvFileLogger.java
@@ -1,0 +1,60 @@
+package com.orhanobut.logger;
+
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * CSV formatted file logging for Android.
+ * Writes to CSV the following data:
+ * epoch timestamp, ISO8601 timestamp (human-readable), log level, tag, log message.
+ */
+public class AndroidCsvFileLogger extends AbstractAndroidFileLogger {
+
+  private static final int MAX_BYTES = 500 * 1024; // 500K averages to a 4000 lines per file
+  private static final String NEW_LINE = System.getProperty("line.separator");
+  private static final String NEW_LINE_REPLACEMENT = " <br> ";
+  private static final String SEPARATOR = ",";
+
+  private final Date date;
+  private final SimpleDateFormat dateFormat;
+
+  public AndroidCsvFileLogger(String folder) {
+    super(MAX_BYTES, folder);
+    this.date = new Date();
+    this.dateFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS", Locale.UK);
+  }
+
+  @Override protected void writeLog(FileWriter fileWriter, int level, String tag, String message) throws IOException {
+    date.setTime(System.currentTimeMillis());
+
+    // machine-readable date/time
+    fileWriter.append(Long.toString(date.getTime()));
+
+    // human-readable date/time
+    fileWriter.append(SEPARATOR);
+    fileWriter.append(dateFormat.format(date));
+
+    // level
+    fileWriter.append(SEPARATOR);
+    fileWriter.append(LogLevel.toString(level));
+
+    // tag
+    fileWriter.append(SEPARATOR);
+    fileWriter.append(tag);
+
+    // message
+    if (message.contains(NEW_LINE)) {
+      // a new line would break the CSV format, so we replace it here
+      message = message.replaceAll(NEW_LINE, NEW_LINE_REPLACEMENT);
+    }
+    fileWriter.append(SEPARATOR);
+    fileWriter.append(message);
+
+    // new line
+    fileWriter.append(NEW_LINE);
+  }
+}

--- a/logger/src/main/java/com/orhanobut/logger/FileLogger.java
+++ b/logger/src/main/java/com/orhanobut/logger/FileLogger.java
@@ -1,0 +1,5 @@
+package com.orhanobut.logger;
+
+public interface FileLogger {
+  void log(int level, String tag, String message);
+}

--- a/logger/src/main/java/com/orhanobut/logger/Helper.java
+++ b/logger/src/main/java/com/orhanobut/logger/Helper.java
@@ -102,4 +102,8 @@ final class Helper {
     return sw.toString();
   }
 
+  static boolean shouldLog(int logLevel, int priority) {
+    return priority >= logLevel;
+  }
+
 }

--- a/logger/src/main/java/com/orhanobut/logger/LogLevel.java
+++ b/logger/src/main/java/com/orhanobut/logger/LogLevel.java
@@ -5,10 +5,50 @@ public enum LogLevel {
   /**
    * Prints all logs
    */
-  FULL,
+  FULL(2),
 
   /**
    * No log will be printed
    */
-  NONE
+  NONE(0);
+
+
+  private final int value;
+
+  LogLevel(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public static final int DISABLED = 0;
+  public static final int VERBOSE = 2;
+  public static final int DEBUG = 3;
+  public static final int INFO = 4;
+  public static final int WARN = 5;
+  public static final int ERROR = 6;
+  public static final int ASSERT = 7;
+
+  public static String toString(int value) {
+    switch (value) {
+      case DISABLED:
+        return "DISABLED";
+      case VERBOSE:
+        return "VERBOSE";
+      case DEBUG:
+        return "DEBUG";
+      case INFO:
+        return "INFO";
+      case WARN:
+        return "WARN";
+      case ERROR:
+        return "ERROR";
+      case ASSERT:
+        return "ASSERT";
+      default:
+        return "UNKNOWN";
+    }
+  }
 }

--- a/logger/src/main/java/com/orhanobut/logger/Logger.java
+++ b/logger/src/main/java/com/orhanobut/logger/Logger.java
@@ -5,12 +5,6 @@ package com.orhanobut.logger;
  * But more pretty, simple and powerful
  */
 public final class Logger {
-  public static final int DEBUG = 3;
-  public static final int ERROR = 6;
-  public static final int ASSERT = 7;
-  public static final int INFO = 4;
-  public static final int VERBOSE = 2;
-  public static final int WARN = 5;
 
   private static final String DEFAULT_TAG = "PRETTYLOGGER";
 

--- a/logger/src/main/java/com/orhanobut/logger/Settings.java
+++ b/logger/src/main/java/com/orhanobut/logger/Settings.java
@@ -1,16 +1,26 @@
 package com.orhanobut.logger;
 
+import android.os.Environment;
+
+import java.io.File;
+
 public final class Settings {
 
   private int methodCount = 2;
   private boolean showThreadInfo = true;
   private int methodOffset = 0;
   private LogAdapter logAdapter;
+  private FileLogger fileLogger;
 
   /**
    * Determines to how logs will be printed
    */
-  private LogLevel logLevel = LogLevel.FULL;
+  private int logLevel = LogLevel.VERBOSE;
+
+  /**
+   * Determines to how logs will be saved to file
+   */
+  private int fileLogLevel = LogLevel.DISABLED;
 
   public Settings hideThreadInfo() {
     showThreadInfo = false;
@@ -26,6 +36,11 @@ public final class Settings {
   }
 
   public Settings logLevel(LogLevel logLevel) {
+    this.logLevel = logLevel.getValue();
+    return this;
+  }
+
+  public Settings logLevel(int logLevel) {
     this.logLevel = logLevel;
     return this;
   }
@@ -40,6 +55,20 @@ public final class Settings {
     return this;
   }
 
+  public Settings fileLogLevel(int fileLogLevel) {
+    this.fileLogLevel = fileLogLevel;
+    return this;
+  }
+
+  public Settings fileLogger(FileLogger fileLogger) {
+    this.fileLogger = fileLogger;
+    return this;
+  }
+
+  public int getFileLogLevel() {
+    return fileLogLevel;
+  }
+
   public int getMethodCount() {
     return methodCount;
   }
@@ -48,7 +77,7 @@ public final class Settings {
     return showThreadInfo;
   }
 
-  public LogLevel getLogLevel() {
+  public int getLogLevel() {
     return logLevel;
   }
 
@@ -63,10 +92,25 @@ public final class Settings {
     return logAdapter;
   }
 
+  /**
+   * Returns the instance of FileLogger, creating one if necessary.
+   * The created logger is a CSV logger and points to the folder "logger" on external storage
+   * If developer wants to use internal folder, he/she must call {@link #fileLogger(FileLogger)}
+   *
+   * @return file logger
+   */
+  public FileLogger getFileLogger() {
+    if (fileLogger == null) {
+      fileLogger = new AndroidCsvFileLogger(
+          Environment.getExternalStorageDirectory().getAbsolutePath() + File.separatorChar + "logger");
+    }
+    return fileLogger;
+  }
+
   public void reset() {
     methodCount = 2;
     methodOffset = 0;
     showThreadInfo = true;
-    logLevel = LogLevel.FULL;
+    logLevel = LogLevel.VERBOSE;
   }
 }

--- a/logger/src/test/java/com.orhanobut.logger/HelperTest.java
+++ b/logger/src/test/java/com.orhanobut.logger/HelperTest.java
@@ -40,4 +40,16 @@ public class HelperTest {
   @Test public void getStackTraceStringReturnEmptyStringWithUnknownHostException() {
     assertThat(Helper.getStackTraceString(new UnknownHostException())).isEqualTo("");
   }
+
+  @Test public void shouldLogReturnsTrueForHigherPriorityThanLogLevel() {
+    assertThat(Helper.shouldLog(LogLevel.DEBUG, LogLevel.WARN)).isEqualTo(true);
+  }
+
+  @Test public void shouldLogReturnsTrueForEqualPriorityAndLogLevel() {
+    assertThat(Helper.shouldLog(LogLevel.DEBUG, LogLevel.DEBUG)).isEqualTo(true);
+  }
+
+  @Test public void shouldLogReturnsFalseForHigherLogLevelThanPriority() {
+    assertThat(Helper.shouldLog(LogLevel.WARN, LogLevel.DEBUG)).isEqualTo(false);
+  }
 }

--- a/logger/src/test/java/com.orhanobut.logger/LoggerTest.java
+++ b/logger/src/test/java/com.orhanobut.logger/LoggerTest.java
@@ -16,13 +16,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.orhanobut.logger.Logger.ASSERT;
-import static com.orhanobut.logger.Logger.DEBUG;
-import static com.orhanobut.logger.Logger.ERROR;
-import static com.orhanobut.logger.Logger.INFO;
-import static com.orhanobut.logger.Logger.VERBOSE;
-import static com.orhanobut.logger.Logger.WARN;
+import static com.orhanobut.logger.LogLevel.ASSERT;
+import static com.orhanobut.logger.LogLevel.DEBUG;
+import static com.orhanobut.logger.LogLevel.ERROR;
+import static com.orhanobut.logger.LogLevel.INFO;
+import static com.orhanobut.logger.LogLevel.VERBOSE;
+import static com.orhanobut.logger.LogLevel.WARN;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)

--- a/logger/src/test/java/com.orhanobut.logger/SettingsTest.java
+++ b/logger/src/test/java/com.orhanobut.logger/SettingsTest.java
@@ -20,15 +20,15 @@ public class SettingsTest {
   }
 
   @Test public void testDefaultLogLevel() {
-    assertThat(settings.getLogLevel()).isEqualTo(LogLevel.FULL);
+    assertThat(settings.getLogLevel()).isEqualTo(LogLevel.FULL.getValue());
   }
 
   @Test public void testCustomLogLevel() {
     settings.logLevel(LogLevel.NONE);
-    assertThat(settings.getLogLevel()).isEqualTo(LogLevel.NONE);
+    assertThat(settings.getLogLevel()).isEqualTo(LogLevel.NONE.getValue());
 
     settings.logLevel(LogLevel.FULL);
-    assertThat(settings.getLogLevel()).isEqualTo(LogLevel.FULL);
+    assertThat(settings.getLogLevel()).isEqualTo(LogLevel.FULL.getValue());
   }
 
   @Test public void testMethodCount() {
@@ -70,7 +70,7 @@ public class SettingsTest {
     settings.reset();
 
     assertThat(settings.getMethodCount()).isEqualTo(2);
-    assertThat(settings.getLogLevel()).isEqualTo(LogLevel.FULL);
+    assertThat(settings.getLogLevel()).isEqualTo(LogLevel.FULL.getValue());
     assertThat(settings.getMethodOffset()).isEqualTo(0);
     assertThat(settings.isShowThreadInfo()).isTrue();
   }


### PR DESCRIPTION
FileLogger diffs from LogAdapter that they receive raw logs (instead of pretty logs)
Added LogLevel for standard logs (VERBOSE, DEBUG, ETC), also kept a back-compat enum with previous values.
LoggerPrinter dispatches pretty log to LogAdapter and raw log to FileLogger depending on respective level.
Created AbstractAndroidFileLogger that dispatches all logs to a background thread and
added AndroidCsvFileLogger that exnteds it and generates CSV logs.

Defaults fileLogLevel to DISABLED.