### PR TITLE
Create DiskLogStrategy Builder

### DIFF
--- a/logger/src/main/java/com/orhanobut/logger/CsvFormatStrategy.java
+++ b/logger/src/main/java/com/orhanobut/logger/CsvFormatStrategy.java
@@ -1,10 +1,5 @@
 package com.orhanobut.logger;
 
-import android.os.Environment;
-import android.os.Handler;
-import android.os.HandlerThread;
-
-import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -88,7 +83,7 @@ public class CsvFormatStrategy implements FormatStrategy {
     private Builder() {
       date = new Date();
       dateFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS", Locale.UK);
-      logStrategy = new DiskLogStrategy.Builder().Build();
+      logStrategy = new DiskLogStrategy.Builder().build();
     }
 
     public Builder date(Date val) {

--- a/logger/src/main/java/com/orhanobut/logger/CsvFormatStrategy.java
+++ b/logger/src/main/java/com/orhanobut/logger/CsvFormatStrategy.java
@@ -80,14 +80,15 @@ public class CsvFormatStrategy implements FormatStrategy {
   }
 
   public static final class Builder {
-    private static final int MAX_BYTES = 500 * 1024; // 500K averages to a 4000 lines per file
-
     Date date;
     SimpleDateFormat dateFormat;
     LogStrategy logStrategy;
     String tag = "PRETTY_LOGGER";
 
     private Builder() {
+      date = new Date();
+      dateFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS", Locale.UK);
+      logStrategy = new DiskLogStrategy.DiskLogStrategyBuilder().Build();
     }
 
     public Builder date(Date val) {
@@ -111,21 +112,6 @@ public class CsvFormatStrategy implements FormatStrategy {
     }
 
     public CsvFormatStrategy build() {
-      if (date == null) {
-        date = new Date();
-      }
-      if (dateFormat == null) {
-        dateFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS", Locale.UK);
-      }
-      if (logStrategy == null) {
-        String diskPath = Environment.getExternalStorageDirectory().getAbsolutePath();
-        String folder = diskPath + File.separatorChar + "logger";
-
-        HandlerThread ht = new HandlerThread("AndroidFileLogger." + folder);
-        ht.start();
-        Handler handler = new DiskLogStrategy.WriteHandler(ht.getLooper(), folder, MAX_BYTES);
-        logStrategy = new DiskLogStrategy(handler);
-      }
       return new CsvFormatStrategy(this);
     }
   }

--- a/logger/src/main/java/com/orhanobut/logger/CsvFormatStrategy.java
+++ b/logger/src/main/java/com/orhanobut/logger/CsvFormatStrategy.java
@@ -88,7 +88,7 @@ public class CsvFormatStrategy implements FormatStrategy {
     private Builder() {
       date = new Date();
       dateFormat = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS", Locale.UK);
-      logStrategy = new DiskLogStrategy.DiskLogStrategyBuilder().Build();
+      logStrategy = new DiskLogStrategy.Builder().Build();
     }
 
     public Builder date(Date val) {

--- a/logger/src/main/java/com/orhanobut/logger/DiskLogStrategy.java
+++ b/logger/src/main/java/com/orhanobut/logger/DiskLogStrategy.java
@@ -109,24 +109,24 @@ public class DiskLogStrategy implements LogStrategy {
     String diskPath;
     String folderName;
 
-    public Builder(){
+    public Builder() {
       diskPath = Environment.getExternalStorageDirectory().getAbsolutePath();
       folderName = "logger";
     }
 
-    public Builder setDiskPath(String diskPath){
+    public Builder setDiskPath(String diskPath) {
       this.diskPath = diskPath;
       return this;
     }
 
-    public Builder setFolderName(String folderName){
+    public Builder setFolderName(String folderName) {
       this.folderName = folderName;
       return this;
     }
 
-    public DiskLogStrategy Build(){
+    public DiskLogStrategy build(){
       String folder = diskPath + File.separatorChar + folderName;
-      HandlerThread ht = new HandlerThread("AndroidFileLogger."+folder);
+      HandlerThread ht = new HandlerThread("AndroidFileLogger." + folder);
       ht.start();
       Handler handler = new DiskLogStrategy.WriteHandler(ht.getLooper(), folder, MAX_BYTES);
       return new DiskLogStrategy(handler);

--- a/logger/src/main/java/com/orhanobut/logger/DiskLogStrategy.java
+++ b/logger/src/main/java/com/orhanobut/logger/DiskLogStrategy.java
@@ -103,23 +103,23 @@ public class DiskLogStrategy implements LogStrategy {
     }
   }
 
-  public static final class DiskLogStrategyBuilder {
+  public static final class Builder {
     private static final int MAX_BYTES = 500 * 1024; // 500K averages to a 4000 lines per file
 
     String diskPath;
     String folderName;
 
-    public DiskLogStrategyBuilder(){
+    public Builder(){
       diskPath = Environment.getExternalStorageDirectory().getAbsolutePath();
       folderName = "logger";
     }
 
-    public DiskLogStrategyBuilder setDiskPath(String diskPath){
+    public Builder setDiskPath(String diskPath){
       this.diskPath = diskPath;
       return this;
     }
 
-    public DiskLogStrategyBuilder setFolderName(String folderName){
+    public Builder setFolderName(String folderName){
       this.folderName = folderName;
       return this;
     }
@@ -131,6 +131,5 @@ public class DiskLogStrategy implements LogStrategy {
       Handler handler = new DiskLogStrategy.WriteHandler(ht.getLooper(), folder, MAX_BYTES);
       return new DiskLogStrategy(handler);
     }
-
   }
 }

--- a/logger/src/main/java/com/orhanobut/logger/DiskLogStrategy.java
+++ b/logger/src/main/java/com/orhanobut/logger/DiskLogStrategy.java
@@ -1,6 +1,8 @@
 package com.orhanobut.logger;
 
+import android.os.Environment;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
 
@@ -99,5 +101,36 @@ public class DiskLogStrategy implements LogStrategy {
 
       return newFile;
     }
+  }
+
+  public static final class DiskLogStrategyBuilder {
+    private static final int MAX_BYTES = 500 * 1024; // 500K averages to a 4000 lines per file
+
+    String diskPath;
+    String folderName;
+
+    public DiskLogStrategyBuilder(){
+      diskPath = Environment.getExternalStorageDirectory().getAbsolutePath();
+      folderName = "logger";
+    }
+
+    public DiskLogStrategyBuilder setDiskPath(String diskPath){
+      this.diskPath = diskPath;
+      return this;
+    }
+
+    public DiskLogStrategyBuilder setFolderName(String folderName){
+      this.folderName = folderName;
+      return this;
+    }
+
+    public DiskLogStrategy Build(){
+      String folder = diskPath + File.separatorChar + folderName;
+      HandlerThread ht = new HandlerThread("AndroidFileLogger."+folder);
+      ht.start();
+      Handler handler = new DiskLogStrategy.WriteHandler(ht.getLooper(), folder, MAX_BYTES);
+      return new DiskLogStrategy(handler);
+    }
+
   }
 }

--- a/logger/src/main/java/com/orhanobut/logger/DiskLogStrategy.java
+++ b/logger/src/main/java/com/orhanobut/logger/DiskLogStrategy.java
@@ -124,7 +124,7 @@ public class DiskLogStrategy implements LogStrategy {
       return this;
     }
 
-    public DiskLogStrategy build(){
+    public DiskLogStrategy build() {
       String folder = diskPath + File.separatorChar + folderName;
       HandlerThread ht = new HandlerThread("AndroidFileLogger." + folder);
       ht.start();


### PR DESCRIPTION
Create DiskLogStategy with DiskLogStrategyBuilder able to let us custom the log folder name and directory with more simple step.

below example if we want to custom log folder name using DiskLogStrategyBuilder

Example:
   ```
 formatStrategy = CsvFormatStrategy.newBuilder()
            .logStrategy(new DiskLogStrategy.DiskLogStrategyBuilder()
                  .setFolderName("MyApp").Build())
            .tag("hello").build();
```

as we can see above example is more simple compare to below example.

example:
 ```
        String diskPath = Environment.getExternalStorageDirectory().getAbsolutePath();
        String folderName = "MyApp";
        String folder = diskPath + File.separatorChar + "logger";
        HandlerThread ht = new HandlerThread("AndroidFileLogger." + folder);
        ht.start();
        Handler handler = new DiskLogStrategy.WriteHandler(ht.getLooper(), folder, 500 * 1024);
        DiskLogStrategy logStrategy = new DiskLogStrategy(handler);

        formatStrategy = CsvFormatStrategy.newBuilder()
            .logStrategy(logStrategy)
            .tag("hello").build();
```

