### PR TITLE
Fix Travis-CI license issue for android 27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ android:
     - build-tools-27.0.3
     - android-27
 
+before_install:
+  - yes | sdkmanager "platforms;android-27"
+
 script:
 - ./gradlew check


### PR DESCRIPTION
Travis somehow doesn't accept license for android 27 and gives the following error.

You have not accepted the license agreements of the following SDK components:
  [Android SDK Platform 27].

It seems the issue is related some checksum changes, therefore the fix is to enforce agreement.