### PR TITLE
Overload error logger

### DIFF
--- a/logger/src/main/java/com/orhanobut/logger/Logger.java
+++ b/logger/src/main/java/com/orhanobut/logger/Logger.java
@@ -123,6 +123,10 @@ public final class Logger {
     printer.e(throwable, message, args);
   }
 
+  public static void e(@Nullable Throwable throwable, @Nullable Object... args) {
+    printer.e(throwable, "", args);
+  }
+
   public static void i(@NonNull String message, @Nullable Object... args) {
     printer.i(message, args);
   }

--- a/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
+++ b/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
@@ -66,7 +66,7 @@ class LoggerPrinter implements Printer {
   }
 
   @Override public void e(@Nullable Throwable throwable, @Nullable Object... args) {
-    e(null, "", args);
+    e(throwable, "", args);
   }
 
   @Override public void w(@NonNull String message, @Nullable Object... args) {

--- a/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
+++ b/logger/src/main/java/com/orhanobut/logger/LoggerPrinter.java
@@ -65,6 +65,10 @@ class LoggerPrinter implements Printer {
     log(ERROR, throwable, message, args);
   }
 
+  @Override public void e(@Nullable Throwable throwable, @Nullable Object... args) {
+    e(null, "", args);
+  }
+
   @Override public void w(@NonNull String message, @Nullable Object... args) {
     log(WARN, null, message, args);
   }

--- a/logger/src/main/java/com/orhanobut/logger/Printer.java
+++ b/logger/src/main/java/com/orhanobut/logger/Printer.java
@@ -21,6 +21,8 @@ public interface Printer {
 
   void e(@Nullable Throwable throwable, @NonNull String message, @Nullable Object... args);
 
+  void e(@Nullable Throwable throwable, @Nullable Object... args);
+
   void w(@NonNull String message, @Nullable Object... args);
 
   void i(@NonNull String message, @Nullable Object... args);

--- a/sample/src/main/java/com/orhanobut/sample/MainActivity.java
+++ b/sample/src/main/java/com/orhanobut/sample/MainActivity.java
@@ -82,5 +82,6 @@ public class MainActivity extends Activity {
     Logger.addLogAdapter(new AndroidLogAdapter(formatStrategy));
 
     Logger.w("my log message with my tag");
+    Logger.e(new Throwable("Only throwable"));
   }
 }


### PR DESCRIPTION
I feel like most of the time the error logging will be used with some callback that returns a throwable, like RxJava or Retrofit and in most of those cases `Logger.e(throwable)` should be enough for the developer to see what's going and address the issue.

Right now we have to do `Logger.e(throwable, "")` around our code or `Logger.e(throwable.getMessage())` which can cause a `NullPointerException` if throwable is `null` 